### PR TITLE
Update definition to include the `.reflect` method, replaces `.inspect` method

### DIFF
--- a/bluebird.d.ts
+++ b/bluebird.d.ts
@@ -129,7 +129,7 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
   /**
    * Synchronously inspect the state of this `promise`. The `PromiseInspection` will represent the state of the promise as snapshotted at the time of calling `.inspect()`.
    */
-  inspect(): Bluebird.Inspection<R>;
+  reflect(): Bluebird.Inspection<R>;
 
   /**
    * This is a convenience method for doing:

--- a/bluebird.d.ts
+++ b/bluebird.d.ts
@@ -127,7 +127,8 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
   reason(): any;
 
   /**
-   * Synchronously inspect the state of this `promise`. The `PromiseInspection` will represent the state of the promise as snapshotted at the time of calling `.inspect()`.
+   * Synchronously inspect the state of this `promise`. The `PromiseInspection` will represent the state of
+   * the promise as snapshotted at the time of calling `.reflect()`.
    */
   reflect(): Bluebird.Inspection<R>;
 

--- a/bluebird.d.ts
+++ b/bluebird.d.ts
@@ -219,12 +219,6 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
   props(): Bluebird<Object>;
 
   /**
-   * Same as calling `Promise.settle(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
-   */
-  // TODO type inference from array-resolving promise?
-  settle<U>(): Bluebird<Bluebird.Inspection<U>[]>;
-
-  /**
    * Same as calling `Promise.any(thisPromise)`. With the exception that if this promise is bound to a value, the returned promise is bound to that value too.
    */
   // TODO type inference from array-resolving promise?
@@ -403,20 +397,6 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
   static props(object: Bluebird<Object>): Bluebird<Object>;
   // object
   static props(object: Object): Bluebird<Object>;
-
-  /**
-   * Given an array, or a promise of an array, which contains promises (or a mix of promises and values) return a promise that is fulfilled when all the items in the array are either fulfilled or rejected. The fulfillment value is an array of ``PromiseInspection`` instances at respective positions in relation to the input array.
-   *
-   * *original: The array is not modified. The input array sparsity is retained in the resulting array.*
-   */
-  // promise of array with promises of value
-  static settle<R>(values: Bluebird.Thenable<Bluebird.Thenable<R>[]>): Bluebird<Bluebird.Inspection<R>[]>;
-  // promise of array with values
-  static settle<R>(values: Bluebird.Thenable<R[]>): Bluebird<Bluebird.Inspection<R>[]>;
-  // array with promises of value
-  static settle<R>(values: Bluebird.Thenable<R>[]): Bluebird<Bluebird.Inspection<R>[]>;
-  // array with values
-  static settle<R>(values: R[]): Bluebird<Bluebird.Inspection<R>[]>;
 
   /**
    * Like `Promise.some()`, with 1 as `count`. However, if the promise fulfills, the fulfillment value is not an array of 1 but the value directly.


### PR DESCRIPTION
The `.inspect` method was removed by [this](https://github.com/petkaantonov/bluebird/commit/9794effd09384e9a9f0974b8b2a141e1c35211ed#diff-71a33078d64e28db727b5848b796c751) commit, and had already been superseded by `.reflect`.

Bluebird API [reference](http://bluebirdjs.com/docs/api/reflect.html)

Closes issue #9 
