### PR TITLE
Fixed .all and added some missing methods

### DIFF
--- a/bluebird.d.ts
+++ b/bluebird.d.ts
@@ -19,7 +19,9 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
    * Alias `.caught();` for compatibility with earlier ECMAScript version.
    */
   catch(onReject?: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
+  caught(onReject?: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
   catch<U>(onReject?: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
+  caught<U>(onReject?: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
 
   /**
    * This extends `.catch` to work more like catch-clauses in languages like Java or C#. Instead of manually checking `instanceof` or `.name === "SomeError"`, you may specify a number of error constructors which are eligible for this catch handler. The catch handler that is first met that has eligible constructors specified, is the one that will be called.
@@ -29,11 +31,17 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
    * Alias `.caught();` for compatibility with earlier ECMAScript version.
    */
   catch(predicate: (error: any) => boolean, onReject: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
+  caught(predicate: (error: any) => boolean, onReject: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
   catch<U>(predicate: (error: any) => boolean, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
+  caught<U>(predicate: (error: any) => boolean, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
   catch(ErrorClass: Function, onReject: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
+  caught(ErrorClass: Function, onReject: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
   catch<U>(ErrorClass: Function, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
+  caught<U>(ErrorClass: Function, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
   catch(predicate: Object, onReject: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
+  caught(predicate: Object, onReject: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
   catch<U>(predicate: Object, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
+  caught<U>(predicate: Object, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
 
   /**
    * Like `.catch` but instead of catching all types of exceptions, it only catches those that don't originate from thrown errors but rather from explicit rejections.
@@ -268,7 +276,6 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
    * Alias for `attempt();` for compatibility with earlier ECMAScript version.
    */
   static try<R>(fn: () => R | Bluebird.Thenable<R>): Bluebird<R>;
-
   static attempt<R>(fn: () => R | Bluebird.Thenable<R>): Bluebird<R>;
 
   /**
@@ -686,6 +693,13 @@ declare namespace Bluebird {
      */
     reason(): any;
   }
+
+  /**
+   * This is relevant to browser environments with no module loader.
+   *
+   * Release control of the Promise namespace to whatever it was before this library was loaded. Returns a reference to the library namespace so you can attach it to something else.
+   */
+  export function noConflict(): typeof Bluebird;
 
   /**
    * Changes how bluebird schedules calls a-synchronously.

--- a/bluebird.d.ts
+++ b/bluebird.d.ts
@@ -377,7 +377,7 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
   static all<T1, T2>(values: [Bluebird.Thenable<T1> | T1, Bluebird.Thenable<T2> | T2]): Bluebird<[T1, T2]>;
   static all<T1>(values: [Bluebird.Thenable<T1> | T1]): Bluebird<[T1]>;
   // array with values
-  static all<R>(values: ((R | Bluebird.Thenable<R>) | Bluebird.Thenable<(R | Bluebird.Thenable<R>)>)[]): Bluebird<R[]>;
+  static all<R>(values: Bluebird.Thenable<(Bluebird.Thenable<R> | R)[]> | (Bluebird.Thenable<R> | R)[]): Bluebird<R[]>;
 
   /**
    * Like ``Promise.all`` but for object properties instead of array items. Returns a promise that is fulfilled when all the properties of the object are fulfilled. The promise's fulfillment value is an object with fulfillment values at respective keys to the original object. If any promise in the object rejects, the returned promise is rejected with the rejection reason.


### PR DESCRIPTION
- fixes the `Promise.all` signature: The previous definition failed for `Promise<R[]>`, while `Promise.any` had the correct definition already, from which I could simply copy it.
- added the `.caught` instance method, as well as the static `getNewLibraryCopy()` and `noConflict()` methods.
