### PR TITLE
Make Thenable assignable to PromiseLike

### DIFF
--- a/bluebird.d.ts
+++ b/bluebird.d.ts
@@ -646,10 +646,10 @@ declare namespace Bluebird {
   }
 
   export interface Thenable<R> {
-    then<U1, U2>(onFulfill: (value: R) => U1 | Bluebird.Thenable<U1>, onReject: (error: any) => U2 | Bluebird.Thenable<U2>): Bluebird.Thenable<U1 | U2>;
-    then<U>(onFulfill: (value: R) => U | Bluebird.Thenable<U>, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird.Thenable<U>;
-    then<U>(onFulfill: (value: R) => U | Bluebird.Thenable<U>): Bluebird.Thenable<U>;
-    then(): Bluebird.Thenable<R>;
+    then<U1, U2>(onFulfill: (value: R) => U1 | Thenable<U1>, onReject: (error: any) => U2 | Thenable<U2>): Thenable<U1 | U2>;
+    then<U>(onFulfill: (value: R) => U | Thenable<U>, onReject: (error: any) => U | Thenable<U>): Thenable<U>;
+    then<U>(onFulfill: (value: R) => U | Thenable<U>): Thenable<U>;
+    then(): Thenable<R>;
   }
 
   export interface Resolver<R> {

--- a/bluebird.d.ts
+++ b/bluebird.d.ts
@@ -646,8 +646,10 @@ declare namespace Bluebird {
   }
 
   export interface Thenable<R> {
-    then<U>(onFulfilled: (value: R) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
-    then<U>(onFulfilled: (value: R) => U | Thenable<U>, onRejected?: (error: any) => void | Thenable<void>): Thenable<U>;
+    then<U1, U2>(onFulfill: (value: R) => U1 | Bluebird.Thenable<U1>, onReject: (error: any) => U2 | Bluebird.Thenable<U2>): Bluebird.Thenable<U1 | U2>;
+    then<U>(onFulfill: (value: R) => U | Bluebird.Thenable<U>, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird.Thenable<U>;
+    then<U>(onFulfill: (value: R) => U | Bluebird.Thenable<U>): Bluebird.Thenable<U>;
+    then(): Bluebird.Thenable<R>;
   }
 
   export interface Resolver<R> {


### PR DESCRIPTION
Add overloads to `Bluebird.Thenable.then` method to correspond with ES6 PromiseLike interface.

See also https://github.com/types/npm-bluebird/pull/29#issuecomment-244891375
